### PR TITLE
Instead of truncating the date fields, standardise to UTC

### DIFF
--- a/raw-compare.js
+++ b/raw-compare.js
@@ -317,11 +317,8 @@ function recursiveIdScan(resource, ignoreParams, ignoreParents, parentId, entryI
 			|| properties[i].toLowerCase().indexOf("authoredon") !== -1
 			|| properties[i].toLowerCase().indexOf("issued") !== -1) {
 
-			if (resource[properties[i]].length >= 25) {
-				responseObject[properties[i]] = resource[properties[i]].substring(0, 19);
-			} else {
-				responseObject[properties[i]] = resource[properties[i]];
-			}
+			const time = new Date(resource[properties[i]]);
+			responseObject[properties[i]] = time.toISOString();
 		} else {
 			responseObject[properties[i]] = resource[properties[i]];
 		}

--- a/raw-compare.test.js
+++ b/raw-compare.test.js
@@ -7,4 +7,18 @@ describe('recursiveIdScan', () => {
         };
         expect(recursiveIdScan(entry, [], [], "", "")).toEqual(entry);
     });
+
+    it('converts date fields to be in UTC', () => {
+        const entry = {
+            'date': '2000-01-01T03:00:00+03:00',
+            'authoredOn': '2000-01-01T02:30:00+02:30',
+            'issued': '1999-12-31T21:00:00-03:00'
+        };
+
+        expect(recursiveIdScan(entry, [], [], "", "")).toEqual({
+            'date': '2000-01-01T00:00:00.000Z',
+            'authoredOn': '2000-01-01T00:00:00.000Z',
+            'issued': '2000-01-01T00:00:00.000Z'
+        });
+    })
 });


### PR DESCRIPTION
Truncating was causing confusion in comparing dates where PS Adaptor was specified in GMT, and TPP is BST.